### PR TITLE
feat: Add verbosity slider for LLM responses

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -116,6 +116,14 @@ def create_orchestrator_agent() -> AgentRunner:
 
     comprehensive_system_prompt = f"""{system_prompt_base}
 Your role is to understand the user's query and use the available tools to gather information, perform tasks, and synthesize a comprehensive final answer.
+
+**Verbosity Control:**
+Before processing the query, check if the user has specified a verbosity level at the very beginning of their message, formatted as 'Verbosity Level: X.' where X is a number from 1 to 5.
+-   **Verbosity Level 1:** Provide a concise and direct answer. Focus on the core information requested, minimizing extra details or contextual explanations.
+-   **Verbosity Level 3 (Default if not specified):** Provide a balanced response with sufficient detail and context.
+-   **Verbosity Level 5:** Provide a highly detailed and comprehensive response. Include extensive explanations, background information, and related concepts where appropriate.
+If a verbosity level is specified, tailor the length, detail, and inclusion of contextual information in your response accordingly. If no level is specified, assume a default verbosity of 3.
+
 You have access to the following tools:
 *   **Search Tools (DuckDuckGo, Tavily, Wikipedia)**: For general web searches, current events, or broad topics.
 *   **Literature Review Tool (Semantic Scholar)**: For finding academic papers and scholarly articles.

--- a/app.py
+++ b/app.py
@@ -147,6 +147,7 @@ def get_agent_response(query: str, chat_history: List[ChatMessage]) -> str:
 
     try:
         current_temperature = st.session_state.get("llm_temperature", 0.7)
+        current_verbosity = st.session_state.get("llm_verbosity", 3) # Default to 3 if not found
 
         if hasattr(agent, 'llm') and hasattr(agent.llm, 'temperature'):
             actual_llm_instance = agent.llm
@@ -154,8 +155,12 @@ def get_agent_response(query: str, chat_history: List[ChatMessage]) -> str:
         else:
             print(f"Warning: Could not access LLM object within the agent to set temperature. Agent or LLM structure might have changed (agent.llm or agent.llm.temperature not found).")
 
+        # Prepend verbosity level to the query
+        modified_query = f"Verbosity Level: {current_verbosity}. {query}"
+        print(f"Modified query with verbosity: {modified_query}")
+
         with st.spinner("ESI is thinking..."):
-            response = agent.chat(query, chat_history=chat_history)
+            response = agent.chat(modified_query, chat_history=chat_history)
 
         response_text = response.response if hasattr(response, 'response') else str(response)
 

--- a/stui.py
+++ b/stui.py
@@ -259,6 +259,15 @@ def create_interface(
                 key="llm_temperature",
                 help="Controls the randomness of the AI's responses. Lower values are more focused, higher values are more creative."
             )
+            st.slider(
+                "Verbosity",
+                min_value=1,
+                max_value=5,
+                value=st.session_state.get("llm_verbosity", 3),
+                step=1,
+                key="llm_verbosity",
+                help="Controls the detail level of the AI's responses. 1 is concise, 5 is very detailed."
+            )
 
         with st.expander("**About ESI**", expanded=False, icon = ":material/info:"):
             st.info("ESI uses AI to help you navigate the dissertation process. It has access to some of the literature in your reading lists and also uses search tools for web lookups.")


### PR DESCRIPTION
This commit introduces a verbosity slider in the LLM settings, allowing you to control the level of detail in my responses.

Key changes:

- Added a slider in `stui.py` ranging from 1 (concise) to 5 (detailed).
- The selected verbosity level is stored in `st.session_state.llm_verbosity`.
- Modified my system prompt in `agent.py` to instruct me to adjust response style based on a verbosity level provided in the query.
- Updated `app.py` to prepend the selected verbosity level to each of your queries before sending it to me (e.g., "Verbosity Level: X. Your query...").

This allows you to customize my output according to your preference for brevity or detail.