### PR TITLE
Fix: Correct Gemini LLM configuration and error reporting

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -30,22 +30,21 @@ def initialize_settings():
         logger.info("Settings.llm and Settings.embed_model are already configured. Skipping re-initialization.")
         return
 
-    logger.info("Configuring Settings.llm and Settings.embed_model...")
+    logger.info("Configuring Settings.llm and Settings.embed_model for Gemini...") # Added "for Gemini" for clarity
     google_api_key = os.getenv("GOOGLE_API_KEY")
     if not google_api_key:
-        logger.error("GOOGLE_API_KEY not found in environment variables.")
-        raise ValueError("GOOGLE_API_KEY not found in environment variables.")
+        logger.error("GOOGLE_API_KEY not found in environment variables. This is required for Gemini.") # Added specificity
+        raise ValueError("GOOGLE_API_KEY not found in environment variables. This is required for Gemini.")
 
     try:
-        # Use Google Generative AI Embeddings
         Settings.embed_model = GoogleGenAIEmbedding(model_name="models/text-embedding-004", api_key=google_api_key)
-        # Use the original model name and temperature setting
-        Settings.llm = Gemini(model_name="models/gemini-2.5-flash-preview-04-17",
+        #                             Ensure this is the correct model name as per user feedback
+        Settings.llm = Gemini(model_name="models/gemini-2.5-flash-preview-05-20", # USER SPECIFIED MODEL
                               api_key=google_api_key,
                               temperature=0.7)
-        logger.info("Settings.llm and Settings.embed_model configured successfully.")
+        logger.info("Settings.llm (Gemini) and Settings.embed_model configured successfully with model gemini-2.5-flash-preview-05-20.")
     except Exception as e:
-        logger.error(f"Error during Settings.llm/Settings.embed_model configuration: {e}")
+        logger.error(f"Error during Gemini LLM/Embedding model configuration (model gemini-2.5-flash-preview-05-20): {e}")
         raise
 
 

--- a/app.py
+++ b/app.py
@@ -40,8 +40,16 @@ def setup_global_llm_settings():
         initialize_agent_settings()
         logger.info("LLM settings initialized (cached).")
     except Exception as e:
-        logger.error(f"Fatal Error: Could not initialize LLM settings. {e}")
-        st.error(f"Fatal Error: Could not initialize LLM settings. {e}")
+        error_message = (
+            "Fatal Error: Could not initialize the AI's language model (Gemini).\n\n"
+            "This is often due to an issue with the GOOGLE_API_KEY setup:\n"
+            "1. Ensure the GOOGLE_API_KEY environment variable is set.\n"
+            "2. Verify the API key is correct and active in your Google AI Studio or Google Cloud console.\n"
+            "3. Check if the API key has permissions for the model being used (e.g., 'gemini-2.5-flash-preview-05-20').\n\n"
+            f"Original error details: {e}"
+        )
+        logger.error(error_message) # Log the more detailed message too
+        st.error(error_message)
         st.stop()
 
 @st.cache_resource


### PR DESCRIPTION
This commit addresses an issue where LLM initialization was failing and incorrectly suggesting an OpenAI configuration problem.

Changes:
- Updated `agent.py` to use the specified Gemini model `models/gemini-2.5-flash-preview-05-20`.
- Verified and ensured `agent.py` correctly uses `GOOGLE_API_KEY` for Gemini LLM and embedding model initialization.
- Enhanced logging in `agent.py` during LLM setup for better clarity.
- Improved the error message in `app.py` when LLM initialization fails, providing more specific troubleshooting steps to you regarding the `GOOGLE_API_KEY` for Gemini.