### PR TITLE
Fix: Correctly route Mistral models via backend mapping

### DIFF
--- a/server/agent.py
+++ b/server/agent.py
@@ -24,6 +24,17 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, Field  # Import Pydantic at the top for BaseModel usage
 load_dotenv()
 
+# Mapping for custom Mistral model IDs to official API names
+MISTRAL_MODEL_MAPPING = {
+    "mistral-large-2411": "mistral-large-latest",
+    "mistral-medium-2508": "mistral-medium-latest",
+    "magistral-medium-2507": "magistral-medium-latest",
+    "mistral-small-latest": "mistral-small-latest",
+    "codestral-latest": "codestral-latest",
+    "open-mistral-nemo": "open-mistral-nemo",
+    "ministral-8b-latest": "ministral-8b-latest",
+}
+
 # Helper function to check if a model is a Mistral model
 def is_mistral_model(model_id: str) -> bool:
     """Check if a model ID is a Mistral model.
@@ -214,8 +225,12 @@ def create_agent(temperature: float = 0.5, model: str = "gemini-2.5-flash", verb
             # Use official ChatMistralAI from langchain-mistralai
             if not mistral_api_key:
                 raise ValueError("MISTRAL_API_KEY environment variable is required for Mistral models")
+
+            # Get the official model name from the mapping
+            official_model_name = MISTRAL_MODEL_MAPPING.get(model, model)
+
             llm = ChatMistralAI(
-                model=model,
+                model=official_model_name,
                 temperature=temperature,
                 mistral_api_key=mistral_api_key,
                 max_retries=2,

--- a/server/main.py
+++ b/server/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from google.auth.exceptions import DefaultCredentialsError
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
+from langchain_mistralai import ChatMistralAI
 from langchain.callbacks.base import BaseCallbackHandler, AsyncCallbackHandler
 import asyncio
 import magic
@@ -19,7 +20,7 @@ import os
 import re
 from pathlib import Path
 
-from agent import create_agent, get_captured_figures, clear_captured_figures
+from agent import create_agent, get_captured_figures, clear_captured_figures, is_mistral_model, MISTRAL_MODEL_MAPPING
 from vector_db import get_vector_db
 from config import settings
 from openrouter_manager import constrain_temperature_for_model
@@ -275,6 +276,14 @@ async def chat_stream(
                 temperature=temperature,
                 google_api_key=settings.GOOGLE_API_KEY,
                 streaming=True,
+            )
+        elif is_mistral_model(model):
+            official_model_name = MISTRAL_MODEL_MAPPING.get(model, model)
+            llm = ChatMistralAI(
+                model=official_model_name,
+                temperature=temperature,
+                streaming=True,
+                mistral_api_key=settings.MISTRAL_API_KEY,
             )
         else:
             # Use OpenRouter manager for consistent model handling

--- a/src/context/Context.jsx
+++ b/src/context/Context.jsx
@@ -18,9 +18,9 @@ const MODEL_CATEGORIES = {
   mistral: {
     label: "Mistral AI",
     models: [
-      { id: "mistral-large-2411", name: "Mistral Large", description: "Top-tier large model for high-complexity tasks", maxTemperature: 1.0, pricing: "premium", provider: "Mistral AI" },
-      { id: "mistral-medium-2508", name: "Mistral Medium", description: "Medium model with excellent performance", maxTemperature: 1.0, pricing: "standard", provider: "Mistral AI" },
-      { id: "magistral-medium-2507", name: "Magistral Medium", description: "Medium sized reasoning model", maxTemperature: 1.0, pricing: "standard", provider: "Mistral AI" },
+      { id: "mistral-large-latest", name: "Mistral Large", description: "Top-tier large model for high-complexity tasks", maxTemperature: 1.0, pricing: "premium", provider: "Mistral AI" },
+      { id: "mistral-medium-latest", name: "Mistral Medium", description: "Medium model with excellent performance", maxTemperature: 1.0, pricing: "standard", provider: "Mistral AI" },
+      { id: "magistral-medium-latest", name: "Magistral Medium", description: "Medium sized reasoning model", maxTemperature: 1.0, pricing: "standard", provider: "Mistral AI" },
       { id: "mistral-small-latest", name: "Mistral Small", description: "Updated small model with excellent performance", maxTemperature: 1.0, pricing: "standard", provider: "Mistral AI" },
       { id: "codestral-latest", name: "Codestral", description: "Specialized model for coding tasks", maxTemperature: 1.0, pricing: "standard", provider: "Mistral AI" },
       { id: "open-mistral-nemo", name: "Mistral Nemo 12B", description: "Best multilingual open source model", maxTemperature: 1.0, pricing: "free", provider: "Mistral AI" },


### PR DESCRIPTION
This change resolves an issue where the Mistral API was rejecting requests due to invalid model IDs, and also fixes a routing issue in the streaming endpoint.

The frontend was sending custom, unrecognized model names (e.g., `mistral-large-2411`). This fix introduces a mapping on the backend (`server/agent.py`) to translate these custom frontend model IDs into the official model names that the Mistral API expects (e.g., `mistral-large-latest`).

Additionally, the streaming endpoint in `server/main.py` has been updated to correctly route Mistral models to the `ChatMistralAI` client and to use the same model mapping. This ensures that both streaming and non-streaming requests for Mistral models are handled correctly and consistently.